### PR TITLE
fix in the detection of width changes

### DIFF
--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -29,7 +29,7 @@ export default function useResponsive() {
     return () => {
       listener.removeEventListener('resize', updateWidth)
     }
-  }, [])
+  }, [width])
 
   return useCallback(
     function responsive(limits: Partial<ResponsiveWidthShorthand> = {}) {


### PR DESCRIPTION
useResponsive hook is not properly detecting changes in screen width (in particular when switching from landscape to portrait mode), which causes undesired behavior.