### PR TITLE
fix: remove unnecessary dependency in usePatchState

### DIFF
--- a/src/hooks/usePatchState.ts
+++ b/src/hooks/usePatchState.ts
@@ -3,12 +3,9 @@ import { useCallback, useState } from 'react'
 export default function usePatchState<T extends object>(initialState: T) {
   const [state, setState] = useState<T>(initialState)
 
-  const patchState = useCallback(
-    (newState: Partial<T>) => {
-      return setState((current) => ({ ...current, ...newState }))
-    },
-    [state]
-  )
+  const patchState = useCallback((newState: Partial<T>) => {
+    return setState((current) => ({ ...current, ...newState }))
+  }, [])
 
   return [state, patchState] as const
 }


### PR DESCRIPTION
`state` as a dependency in `patchOptions` function was causing re-rendering issues when patchOptions was used as dependency for other hooks.

<img width="863" alt="Screen Shot 2022-05-23 at 16 37 19" src="https://user-images.githubusercontent.com/8242162/169894065-ab8ca70d-2313-41da-8ebb-bef3f8b0a717.png">

