### PR TITLE
wip: add semantic form

### DIFF
--- a/src/components/SemanticForm/Input.css
+++ b/src/components/SemanticForm/Input.css
@@ -1,0 +1,19 @@
+.ui.input.action .ui.button {
+  min-width: auto;
+}
+
+.ui.input > .ui.input > input {
+  border-radius: 0;
+}
+
+.ui.input > input:first-child,
+.ui.input > .ui.input:first-child > input {
+  border-radius: 4px 0 0 4px;
+  border-right-color: white;
+}
+
+.ui.input > input:last-child,
+.ui.input > .ui.input:last-child > input {
+  border-radius: 0 4px 4px 0;
+  border-right-color: rgba(34, 36, 38, 0.15);
+}

--- a/src/components/SemanticForm/Input.stories.mdx
+++ b/src/components/SemanticForm/Input.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs'
+import Time from '../../utils/date/Time'
+import Input from './Input.tsx'
+
+<Meta title="Components/SemanticForm/Input" />
+
+<Canvas isExpanded>
+  <Story name="text">
+    <Input />
+  </Story>
+</Canvas>
+
+<Canvas isExpanded>
+  <Story name="date">
+    <Input type="date" />
+    <div />
+    <Input type="date" initialValue={new Date()} onChange={console.log} />
+    <div />
+    <Input type="date" initialValue={Date.now()} utc onChange={console.log} />
+    <div />
+    <Input
+      type="date"
+      initialValue={Date.now()}
+      utc={false}
+      onChange={console.log}
+    />
+  </Story>
+</Canvas>
+
+<Canvas isExpanded>
+  <Story name="time">
+    <Input type="time" />
+    <div />
+    <Input type="time" initialValue={0} onChange={console.log} />
+    <div />
+    <Input
+      type="time"
+      value={22 * Time.Hour + 58 * Time.Minute}
+      onChange={console.log}
+    />
+  </Story>
+</Canvas>
+
+<Canvas isExpanded>
+  <Story name="datetime">
+    <Input type="datetime" />
+    <div />
+    <Input type="datetime" initialValue={new Date()} onChange={console.log} />
+    <div />
+    <Input
+      type="datetime"
+      initialValue={Date.now()}
+      utc
+      onChange={console.log}
+    />
+    <div />
+    <Input
+      type="datetime"
+      initialValue={Date.now()}
+      utc={false}
+      onChange={console.log}
+    />
+  </Story>
+</Canvas>

--- a/src/components/SemanticForm/Input.tsx
+++ b/src/components/SemanticForm/Input.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import InputBase, {
+  InputProps as InputBaseProps,
+} from 'semantic-ui-react/dist/commonjs/elements/Input'
+
+import InputDate, { InputDateProps } from './InputDate'
+import InputDateTime, { InputDateTimeProps } from './InputDateTime'
+import InputTime, { InputTimeProps } from './InputTime'
+
+import './Input.css'
+
+export type InputProps =
+  | InputTimeProps
+  | InputDateProps
+  | InputDateTimeProps
+  | InputBaseProps
+
+export default React.memo(function Input(props: InputProps) {
+  switch (props.type) {
+    case 'time':
+      return <InputTime {...(props as InputTimeProps)} />
+    case 'date':
+      return <InputDate {...(props as InputDateProps)} />
+    case 'datetime':
+      return <InputDateTime {...(props as InputDateProps)} />
+    default:
+      return <InputBase {...(props as InputBaseProps)} />
+  }
+})

--- a/src/components/SemanticForm/InputDate.tsx
+++ b/src/components/SemanticForm/InputDate.tsx
@@ -1,0 +1,107 @@
+import React, { useCallback, useMemo, useState } from 'react'
+
+import omit from 'lodash/omit'
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button'
+import InputBase, {
+  InputOnChangeData as InputBaseOnChangeData,
+  InputProps as InputBaseProps,
+} from 'semantic-ui-react/dist/commonjs/elements/Input'
+
+import Time from '../../utils/date/Time'
+
+import './Input.css'
+
+export type InputDateProps = Omit<InputBaseProps, 'type' | 'defaultValue'> & {
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    data: InputDateProps
+  ) => void
+  initialValue?: Date | Time.Dayjs | number
+  value?: Date | Time.Dayjs | number
+  utc?: boolean
+}
+
+export default React.memo(function InputDate(props: InputDateProps) {
+  const [utc, setUTC] = useState(props.utc)
+  const initialValue = useMemo(
+    () => toInputDateValue(props.initialValue, utc),
+    [props.initialValue, utc]
+  )
+  const value = useMemo(
+    () => toInputDateValue(props.value, utc),
+    [props.value, utc]
+  )
+  const handleChangeUTC = useCallback(() => setUTC((prev) => !prev), [])
+  const handleChange = useCallback(
+    (
+      event: React.ChangeEvent<HTMLInputElement>,
+      data: InputBaseOnChangeData
+    ) => {
+      if (props.onChange) {
+        const value = fromInputDateValue(data.value, utc)
+        props.onChange(event, { ...props, value })
+      }
+    },
+    [props.onChange, utc]
+  )
+
+  return (
+    <InputBase
+      {...omit(props, ['utc', 'initialValue'])}
+      value={value}
+      defaultValue={initialValue}
+      type="date"
+      onChange={handleChange}
+      action={props.action || utc !== undefined}
+    >
+      <input />
+      {utc !== undefined && (
+        <Button
+          labelPosition="right"
+          icon={utc ? 'check' : 'time'}
+          positive={utc}
+          content={utc ? 'UTC' : 'Local'}
+          onClick={handleChangeUTC}
+        />
+      )}
+    </InputBase>
+  )
+})
+
+export function toInputDateValue(
+  value?: Date | Time.Dayjs | number,
+  utc?: boolean
+) {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return undefined
+    }
+
+    if (value < 0) {
+      value = 0
+    }
+  }
+
+  return Time.from(value, { utc }).format(Time.Formats.InputDate)
+}
+
+export function fromInputDateValue(value: string | undefined, utc?: boolean) {
+  if (!value) {
+    return undefined
+  }
+
+  const result = Time.from(value, {
+    utc,
+    format: Time.Formats.InputDate,
+  }).toDate()
+
+  if (!Number.isFinite(result.getTime())) {
+    return undefined
+  }
+
+  return result
+}

--- a/src/components/SemanticForm/InputDateTime.tsx
+++ b/src/components/SemanticForm/InputDateTime.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback, useMemo, useState } from 'react'
+
+import omit from 'lodash/omit'
+import Button from 'semantic-ui-react/dist/commonjs/elements/Button'
+import InputBase, {
+  InputOnChangeData as InputBaseOnChangeData,
+  InputProps as InputBaseProps,
+} from 'semantic-ui-react/dist/commonjs/elements/Input'
+
+import Time from '../../utils/date/Time'
+import { fromInputDateValue } from './InputDate'
+
+import './Input.css'
+
+export type InputDateTimeProps = Omit<
+  InputBaseProps,
+  'type' | 'defaultValue'
+> & {
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    data: InputDateTimeProps
+  ) => void
+  initialValue?: Date | Time.Dayjs | number
+  value?: Date | Time.Dayjs | number
+  utc?: boolean
+}
+
+export default React.memo(function InputDateTime(props: InputDateTimeProps) {
+  const [utc, setUTC] = useState(props.utc)
+  const [initialDateValue, initialTimeValue] = useMemo(
+    () => toInputDateTimeValues(props.initialValue, utc),
+    [props.initialValue, utc]
+  )
+  const [dateValue, timeValue] = useMemo(
+    () => toInputDateTimeValues(props.value, utc),
+    [props.value, utc]
+  )
+  const handleChangeUTC = useCallback(() => setUTC((prev) => !prev), [])
+  const handleChangeDate = useCallback(
+    (
+      event: React.ChangeEvent<HTMLInputElement>,
+      data: InputBaseOnChangeData
+    ) => {
+      if (props.onChange) {
+        const value = fromInputDateValue(data.value, utc)
+        props.onChange(event, { ...props, value })
+      }
+    },
+    [props.onChange, utc]
+  )
+
+  const handleChangeTime = useCallback(() => {}, [])
+
+  console.log('initialValue', [initialDateValue, initialTimeValue])
+  console.log('value', [dateValue, timeValue])
+
+  return (
+    <InputBase
+      {...omit(props, ['utc', 'initialValue'])}
+      value={dateValue}
+      defaultValue={initialDateValue}
+      type="date"
+      onChange={handleChangeDate}
+      action={props.action || utc !== undefined}
+    >
+      <input />
+      <InputBase
+        {...omit(props, ['utc', 'initialValue'])}
+        value={timeValue}
+        defaultValue={initialTimeValue}
+        type="time"
+        onChange={handleChangeTime}
+      />
+      {utc !== undefined && (
+        <Button
+          labelPosition="right"
+          icon={utc ? 'check' : 'time'}
+          positive={utc}
+          content={utc ? 'UTC' : 'Local'}
+          onClick={handleChangeUTC}
+        />
+      )}
+    </InputBase>
+  )
+})
+
+export function toInputDateTimeValues(
+  value?: Date | Time.Dayjs | number,
+  utc?: boolean
+) {
+  if (value === undefined || value === null) {
+    return [undefined, undefined] as const
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return [undefined, undefined] as const
+    }
+
+    if (value < 0) {
+      value = 0
+    }
+  }
+
+  const datetime = Time.from(value, { utc })
+  const date = datetime.format(Time.Formats.InputDate)
+  const time = Time.duration(
+    datetime.diff(Time.from(datetime, { utc }).startOf('day'))
+  ).format(Time.Formats.InputTime)
+
+  return [date, time] as const
+}
+
+export function fromInputDateTimeValues(
+  value: string | undefined,
+  utc?: boolean
+) {
+  if (!value) {
+    return undefined
+  }
+
+  const result = Time.from(value, {
+    utc,
+    format: Time.Formats.InputDate,
+  }).toDate()
+
+  if (!Number.isFinite(result.getTime())) {
+    return undefined
+  }
+
+  return result
+}

--- a/src/components/SemanticForm/InputTime.tsx
+++ b/src/components/SemanticForm/InputTime.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useMemo } from 'react'
+
+import omit from 'lodash/omit'
+import InputBase, {
+  InputOnChangeData as InputBaseOnChangeData,
+  InputProps as InputBaseProps,
+} from 'semantic-ui-react/dist/commonjs/elements/Input'
+
+import Time from '../../utils/date/Time'
+import mod from '../../utils/number/mod'
+
+import './Input.css'
+
+export type InputTimeProps = Omit<InputBaseProps, 'type' | 'defaultValue'> & {
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    data: InputTimeProps
+  ) => void
+  initialValue?: number
+  value?: number
+}
+
+export default React.memo(function InputTime(props: InputTimeProps) {
+  const initialValue = useMemo(
+    () => toInputTimeValue(props.initialValue),
+    [props.initialValue]
+  )
+  const value = useMemo(() => toInputTimeValue(props.value), [props.value])
+  const handleChange = useCallback(
+    (
+      event: React.ChangeEvent<HTMLInputElement>,
+      data: InputBaseOnChangeData
+    ) => {
+      if (props.onChange) {
+        const value = fromInputTimeValue(data.value)
+        props.onChange(event, { ...props, value })
+      }
+    },
+    [props.onChange]
+  )
+
+  return (
+    <InputBase
+      {...omit(props, ['initialValue'])}
+      value={value}
+      defaultValue={initialValue}
+      type="time"
+      onChange={handleChange}
+    />
+  )
+})
+
+export function toInputTimeValue(value?: number) {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  return Time.duration(mod(value, Time.Day)).format(Time.Formats.InputTime)
+}
+
+export function fromInputTimeValue(value: string | undefined) {
+  if (!value) {
+    return undefined
+  }
+
+  const [hours, minutes] = value.split(':').map(Number)
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+    return undefined
+  }
+
+  const result = hours * Time.Hour + minutes * Time.Minute
+  return Math.min(Math.max(result, 0), Time.Day - 1)
+}


### PR DESCRIPTION
- [ ] expose [`Input`](https://react.semantic-ui.com/elements/input/) from semantic ui
- [ ] support `type="time"`, use `number` as value
- [ ] support `type="date"`, use `Date` as value
- [ ] support `type="datetime"`, use `Date` as value, support `UTC`
- [ ] expose [`TextArea`](https://react.semantic-ui.com/addons/text-area/) from semantic ui
- [ ] add `TextAreaMarkdown`
    - [ ] use `TextArea` as base
    - [ ] use [`SME`](https://github.com/sparksuite/simplemde-markdown-editor) as editor
    - [ ] use Github style for editor
    - [ ] support file drop