### PR TITLE
feat: Integrate SSO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dcl/crypto": "^3.4.3",
         "@dcl/feature-flags": "^1.2.0",
+        "@dcl/single-sign-on-client": "^0.0.13",
         "@dcl/ui-env": "^1.3.0",
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
@@ -4008,6 +4009,14 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@dcl/single-sign-on-client": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.0.13.tgz",
+      "integrity": "sha512-cYGdMSO9YekoehELhPgePwPZt4FHGm09nNrFaB6ROL7Hr/CFDuTq4qDHNAvf4H4S8EYIK7sPgKTGL5OnlPoHqw==",
+      "dependencies": {
+        "@dcl/crypto": "^3.4.3"
       }
     },
     "node_modules/@dcl/ui-env": {
@@ -62811,6 +62820,14 @@
             "fast-deep-equal": "^3.1.3"
           }
         }
+      }
+    },
+    "@dcl/single-sign-on-client": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@dcl/single-sign-on-client/-/single-sign-on-client-0.0.13.tgz",
+      "integrity": "sha512-cYGdMSO9YekoehELhPgePwPZt4FHGm09nNrFaB6ROL7Hr/CFDuTq4qDHNAvf4H4S8EYIK7sPgKTGL5OnlPoHqw==",
+      "requires": {
+        "@dcl/crypto": "^3.4.3"
       }
     },
     "@dcl/ui-env": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
   "dependencies": {
     "@dcl/crypto": "^3.4.3",
     "@dcl/feature-flags": "^1.2.0",
+    "@dcl/single-sign-on-client": "^0.0.13",
     "@dcl/ui-env": "^1.3.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",

--- a/src/context/Auth/AuthProvider.tsx
+++ b/src/context/Auth/AuthProvider.tsx
@@ -1,8 +1,10 @@
-import React, { createContext } from 'react'
+import React, { createContext, useEffect } from 'react'
+
+import * as SSO from '@dcl/single-sign-on-client'
 
 import useAuth from '../../hooks/useAuth'
-import { AuthOptions } from '../../hooks/useAuth.utils'
 import useTransaction from '../../hooks/useTransaction'
+import { AuthProviderProps } from './utils'
 
 const defaultAuthState: ReturnType<typeof useAuth> = [
   null,
@@ -30,15 +32,26 @@ const defaultTransactionState: ReturnType<typeof useTransaction> = [
 
 export const AuthContext = createContext(defaultAuthState)
 export const TransactionContext = createContext(defaultTransactionState)
-export default React.memo(function AuthProvider(
-  props: React.PropsWithChildren<AuthOptions>
-) {
-  const auth = useAuth(props)
+export default React.memo(function AuthProvider({
+  sso,
+  children,
+}: React.PropsWithChildren<AuthProviderProps>) {
+  const auth = useAuth()
   const transactions = useTransaction(auth[0], auth[1].chainId)
+
+  // Initialize SSO
+  // Will only be initialized if the sso url is provided.
+  // If the url is not provided, the identity of the user will be stored in the application's local storage instead of the sso local storage.
+  useEffect(() => {
+    if (sso) {
+      SSO.init(sso)
+    }
+  }, [])
+
   return (
     <AuthContext.Provider value={auth}>
       <TransactionContext.Provider value={transactions}>
-        {props.children}
+        {children}
       </TransactionContext.Provider>
     </AuthContext.Provider>
   )

--- a/src/context/Auth/AuthProvider.tsx
+++ b/src/context/Auth/AuthProvider.tsx
@@ -1,8 +1,8 @@
 import React, { createContext } from 'react'
 
 import useAuth from '../../hooks/useAuth'
-import useTransaction from '../../hooks/useTransaction'
 import { AuthOptions } from '../../hooks/useAuth.utils'
+import useTransaction from '../../hooks/useTransaction'
 
 const defaultAuthState: ReturnType<typeof useAuth> = [
   null,

--- a/src/context/Auth/AuthProvider.tsx
+++ b/src/context/Auth/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useEffect } from 'react'
 
 import * as SSO from '@dcl/single-sign-on-client'
+import isURL from 'validator/lib/isURL'
 
 import useAuth from '../../hooks/useAuth'
 import useTransaction from '../../hooks/useTransaction'
@@ -43,7 +44,7 @@ export default React.memo(function AuthProvider({
   // Will only be initialized if the sso url is provided.
   // If the url is not provided, the identity of the user will be stored in the application's local storage instead of the sso local storage.
   useEffect(() => {
-    if (sso) {
+    if (sso && isURL(sso)) {
       SSO.init(sso)
     }
   }, [])

--- a/src/context/Auth/AuthProvider.tsx
+++ b/src/context/Auth/AuthProvider.tsx
@@ -2,6 +2,7 @@ import React, { createContext } from 'react'
 
 import useAuth from '../../hooks/useAuth'
 import useTransaction from '../../hooks/useTransaction'
+import { AuthOptions } from '../../hooks/useAuth.utils'
 
 const defaultAuthState: ReturnType<typeof useAuth> = [
   null,
@@ -30,9 +31,9 @@ const defaultTransactionState: ReturnType<typeof useTransaction> = [
 export const AuthContext = createContext(defaultAuthState)
 export const TransactionContext = createContext(defaultTransactionState)
 export default React.memo(function AuthProvider(
-  props: React.PropsWithChildren<{}>
+  props: React.PropsWithChildren<AuthOptions>
 ) {
-  const auth = useAuth()
+  const auth = useAuth(props)
   const transactions = useTransaction(auth[0], auth[1].chainId)
   return (
     <AuthContext.Provider value={auth}>

--- a/src/context/Auth/useAuthContext.stories.mdx
+++ b/src/context/Auth/useAuthContext.stories.mdx
@@ -67,9 +67,13 @@ export default function Component() {
 }
 ```
 
-## Props
+## Single Sign on
 
-The AuthProvider component accept some optional props, `ssoEnabled` and `ssoUrl`
+The AuthProvider receives an additional prop `sso`.
+
+By providing a valid url to this prop, the identity of the user will be stored in the local storage of the Single Sign On application hosted there instead of the current application.
+
+This is useful when you want to share the same identity between multiple applications.
 
 ```tsx dark=true
 // gatsby-browser.js
@@ -78,15 +82,16 @@ import ReactDOM from 'react-dom'
 import AuthProvider from 'decentraland-gatsby/dist/context/Auth/AuthProvider'
 
 export const wrapRootElement = ({ element }) => (
-  <AuthProvider ssoEnabled ssoUrl="https://id.decentraland.zone">
+  <AuthProvider sso="https://id.decentraland.zone">
     {element}
   </AuthProvider>
 )
 ```
 
-These props are provided to the underlying `useAuth` hook to control the usage of the SSO feature.
+You can learn more about SSO in:
 
-You can read more about it on the _Single Sign On_ section of the [`useAuth` documentation](./?path=/story/hooks-useauth--page)
+- https://github.com/decentraland/single-sign-on-client/blob/main/packages/lib/README.md
+- https://github.com/decentraland/single-sign-on
 
 Read the [full documentation](./?path=/story/hooks-useauth--page)
 

--- a/src/context/Auth/useAuthContext.stories.mdx
+++ b/src/context/Auth/useAuthContext.stories.mdx
@@ -67,6 +67,25 @@ export default function Component() {
 }
 ```
 
+## Props
+
+The AuthProvider component accept some optional props, `ssoEnabled` and `ssoUrl`
+
+```tsx dark=true
+// gatsby-browser.js
+import React from 'react'
+import ReactDOM from 'react-dom'
+import AuthProvider from 'decentraland-gatsby/dist/context/Auth/AuthProvider'
+
+export const wrapRootElement = ({ element }) => (
+  <AuthProvider ssoEnabled ssoUrl="https://id.decentraland.zone">{element}</AuthProvider>
+)
+```
+
+These props are provided to the underlying `useAuth` hook to control the usage of the SSO feature.
+
+You can read more about it on the *Single Sign On* section of the [`useAuth` documentation](./?path=/story/hooks-useauth--page)
+
 Read the [full documentation](./?path=/story/hooks-useauth--page)
 
 ## Related hooks

--- a/src/context/Auth/useAuthContext.stories.mdx
+++ b/src/context/Auth/useAuthContext.stories.mdx
@@ -78,13 +78,15 @@ import ReactDOM from 'react-dom'
 import AuthProvider from 'decentraland-gatsby/dist/context/Auth/AuthProvider'
 
 export const wrapRootElement = ({ element }) => (
-  <AuthProvider ssoEnabled ssoUrl="https://id.decentraland.zone">{element}</AuthProvider>
+  <AuthProvider ssoEnabled ssoUrl="https://id.decentraland.zone">
+    {element}
+  </AuthProvider>
 )
 ```
 
 These props are provided to the underlying `useAuth` hook to control the usage of the SSO feature.
 
-You can read more about it on the *Single Sign On* section of the [`useAuth` documentation](./?path=/story/hooks-useauth--page)
+You can read more about it on the _Single Sign On_ section of the [`useAuth` documentation](./?path=/story/hooks-useauth--page)
 
 Read the [full documentation](./?path=/story/hooks-useauth--page)
 

--- a/src/context/Auth/useAuthContext.stories.mdx
+++ b/src/context/Auth/useAuthContext.stories.mdx
@@ -82,9 +82,7 @@ import ReactDOM from 'react-dom'
 import AuthProvider from 'decentraland-gatsby/dist/context/Auth/AuthProvider'
 
 export const wrapRootElement = ({ element }) => (
-  <AuthProvider sso="https://id.decentraland.zone">
-    {element}
-  </AuthProvider>
+  <AuthProvider sso="https://id.decentraland.zone">{element}</AuthProvider>
 )
 ```
 

--- a/src/context/Auth/utils.ts
+++ b/src/context/Auth/utils.ts
@@ -20,3 +20,8 @@ export function getDefaultChainId(): ChainId {
 export function getChainId(): ChainId {
   return CHAIN_ID[0]
 }
+
+export type AuthProviderProps = {
+  // Url of the sso application (Eg: https://id.decentraland.org)
+  sso?: string
+}

--- a/src/hooks/useAuth.stories.mdx
+++ b/src/hooks/useAuth.stories.mdx
@@ -69,6 +69,32 @@ const [account, state] = useAuth()
   ]}
 />
 
+# Single Sign On
+
+Part of the auth flow is generating the identity of the user which is stored in the browser, using the application's local storage.
+
+This hook allows the usage of Single Sign On (SSO), a service that allows users to keep the same identity across multiple decentraland applications without the need of asking the user to generate it multiple times.
+
+SSO can be enabled by passing the `ssoEnabled` option to the `useAuth` hook.
+
+```ts
+const [account, state] = useAuth({ ssoEnabled: true })
+```
+
+By default, SSO uses https://id.decentraland.org, but by providing another url via the `ssoUrl` option, it can use the SSO from another domain.
+
+```ts
+const [account, state] = useAuth({
+  ssoEnabled: true,
+  ssoUrl: 'https://id.decentraland.zone',
+})
+```
+
+You can learn more about SSO in:
+
+- https://github.com/decentraland/single-sign-on-client/blob/main/packages/lib/README.md
+- https://github.com/decentraland/single-sign-on
+
 ## Connect Preview
 
 export const ConnectExample = () => {

--- a/src/hooks/useAuth.stories.mdx
+++ b/src/hooks/useAuth.stories.mdx
@@ -10,6 +10,8 @@ import { Args } from '../components/Storybook/utils'
 import Container from '../components/Storybook/Container'
 import Textarea from '../components/Form/Textarea'
 import Paragraph from '../components/Text/Paragraph'
+import AuthProvider from '../context/Auth/AuthProvider'
+import useAuthContext from '../context/Auth/useAuthContext'
 import useAuth from './useAuth'
 import { chains } from './useAuth.utils'
 
@@ -69,36 +71,10 @@ const [account, state] = useAuth()
   ]}
 />
 
-# Single Sign On
-
-Part of the auth flow is generating the identity of the user which is stored in the browser, using the application's local storage.
-
-This hook allows the usage of Single Sign On (SSO), a service that allows users to keep the same identity across multiple decentraland applications without the need of asking the user to generate it multiple times.
-
-SSO can be enabled by passing the `ssoEnabled` option to the `useAuth` hook.
-
-```ts
-const [account, state] = useAuth({ ssoEnabled: true })
-```
-
-By default, SSO uses https://id.decentraland.org, but by providing another url via the `ssoUrl` option, it can use the SSO from another domain.
-
-```ts
-const [account, state] = useAuth({
-  ssoEnabled: true,
-  ssoUrl: 'https://id.decentraland.zone',
-})
-```
-
-You can learn more about SSO in:
-
-- https://github.com/decentraland/single-sign-on-client/blob/main/packages/lib/README.md
-- https://github.com/decentraland/single-sign-on
-
 ## Connect Preview
 
 export const ConnectExample = () => {
-  const [account, state] = useAuth()
+  const [account, state] = useAuthContext()
   const [chain, setChain] = useState(ChainId.ETHEREUM_MAINNET)
   const selectChain = (_, { value }) => setChain(value)
   const connectInjected = () => state.connect(ProviderType.INJECTED, chain)
@@ -237,7 +213,15 @@ export const ConnectExample = () => {
   )
 }
 
-<ConnectExample />
+export const ConnectExampleWrapper = () => {
+  return (
+    <AuthProvider sso="https://id.decentraland.zone">
+      <ConnectExample />
+    </AuthProvider>
+  )
+}
+
+<ConnectExampleWrapper />
 
 ```tsx dark=true
 import React from 'react'

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,7 +8,6 @@ import logger from '../entities/Development/logger'
 import { setCurrentIdentity } from '../utils/auth/storage'
 import rollbar from '../utils/development/rollbar'
 import segment from '../utils/development/segment'
-import { PersistedKeys } from '../utils/loader/types'
 import useAsyncTask from './useAsyncTask'
 import {
   AuthEvent,
@@ -16,14 +15,12 @@ import {
   AuthState,
   AuthStatus,
   createConnection,
-  getListener,
   initialState,
   isLoading,
   restoreConnection,
   switchToChainId,
 } from './useAuth.utils'
 
-import type { Identity } from '../utils/auth'
 import type { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 
 export { initialState }
@@ -144,53 +141,6 @@ export default function useAuth(options?: AuthOptions) {
       } catch (e) {
         console.warn(e.message)
       }
-    }
-  }, [])
-
-  // bootstrap
-  useEffect(() => {
-    let cancelled = false
-    function updateIdetity(newIdentity: Identity | null) {
-      if (!cancelled) {
-        setState((currentState) => {
-          if (currentState.identity === newIdentity) {
-            return currentState
-          }
-
-          if (newIdentity) {
-            return {
-              status: AuthStatus.Restoring,
-              selecting: false,
-              account: null,
-              identity: null,
-              provider: null,
-              providerType: null,
-              chainId: null,
-              error: null,
-            }
-          }
-
-          return {
-            status: AuthStatus.Disconnecting,
-            selecting: false,
-            account: null,
-            identity: null,
-            provider: null,
-            providerType: null,
-            chainId: null,
-            error: null,
-          }
-        })
-      }
-    }
-
-    getListener().addEventListener(PersistedKeys.Identity as any, updateIdetity)
-    return () => {
-      cancelled = true
-      getListener().removeEventListener(
-        PersistedKeys.Identity as any,
-        updateIdetity
-      )
     }
   }, [])
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -127,7 +127,7 @@ export default function useAuth(options?: AuthOptions) {
   useEffect(() => {
     // Determines if SSO has to be enabled or not.
     // Defaults to false.
-    if (!!options?.ssoEnabled) {
+    if (options?.ssoEnabled) {
       // Use the provided url or defaults to the .org id url.
       const url = options?.ssoUrl ?? 'https://id.decentraland.org'
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -127,9 +127,7 @@ export default function useAuth(options?: AuthOptions) {
   useEffect(() => {
     // Determines if SSO has to be enabled or not.
     // Defaults to false.
-    const ssoEnabled = !!options?.ssoEnabled
-
-    if (ssoEnabled) {
+    if (!!options?.ssoEnabled) {
       // Use the provided url or defaults to the .org id url.
       const url = options?.ssoUrl ?? 'https://id.decentraland.org'
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -129,16 +129,16 @@ export default function useAuth(options?: AuthOptions) {
   // Initialize SSO
   useEffect(() => {
     // Determines if SSO has to be enabled or not.
-    // It will be enabled if not specified.
-    const ssoEnabled = options?.ssoEnabled ?? true
+    // Defaults to false.
+    const ssoEnabled = !!options?.ssoEnabled
 
     if (ssoEnabled) {
-      // Use the url defined in the options or uses org iframe src.
+      // Use the provided url or defaults to the .org id url.
       const url = options?.ssoUrl ?? 'https://id.decentraland.org'
 
-      // If useAuth is used multiple times, SSO.init will fail because it cannot be called more than once.
-      // The hook seems to be intended to be called only once per session so this should not be an issue.
-      // This will prevent execution from breaking in case it happens.
+      // SSO can only be initialized once.
+      // This catch just prevents the lifecycle to break in case it is called more than once.
+      // Given how this hook is used, it is only called once so it might not be necessary.
       try {
         SSO.init(url)
       } catch (e) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
-import * as SSO from '@dcl/single-sign-on-client'
 import { connection } from 'decentraland-connect/dist/ConnectionManager'
 
 import logger from '../entities/Development/logger'
@@ -11,7 +10,6 @@ import segment from '../utils/development/segment'
 import useAsyncTask from './useAsyncTask'
 import {
   AuthEvent,
-  AuthOptions,
   AuthState,
   AuthStatus,
   createConnection,
@@ -27,7 +25,7 @@ export { initialState }
 
 let CONNECTION_PROMISE: Promise<AuthState> | null = null
 
-export default function useAuth(options?: AuthOptions) {
+export default function useAuth() {
   const [state, setState] = useState<AuthState>({ ...initialState })
 
   const select = useCallback(
@@ -122,25 +120,6 @@ export default function useAuth(options?: AuthOptions) {
     },
     [state]
   )
-
-  // Initialize SSO
-  useEffect(() => {
-    // Determines if SSO has to be enabled or not.
-    // Defaults to false.
-    if (options?.ssoEnabled) {
-      // Use the provided url or defaults to the .org id url.
-      const url = options?.ssoUrl ?? 'https://id.decentraland.org'
-
-      // SSO can only be initialized once.
-      // This catch just prevents the lifecycle to break in case it is called more than once.
-      // Given how this hook is used, it is only called once so it might not be necessary.
-      try {
-        SSO.init(url)
-      } catch (e) {
-        console.warn(e.message)
-      }
-    }
-  }, [])
 
   // connect or disconnect
   useEffect(() => {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
-import { connection } from 'decentraland-connect/dist/ConnectionManager'
 import * as SSO from '@dcl/single-sign-on-client'
+import { connection } from 'decentraland-connect/dist/ConnectionManager'
 
 import logger from '../entities/Development/logger'
 import { setCurrentIdentity } from '../utils/auth/storage'
@@ -12,9 +12,9 @@ import { PersistedKeys } from '../utils/loader/types'
 import useAsyncTask from './useAsyncTask'
 import {
   AuthEvent,
+  AuthOptions,
   AuthState,
   AuthStatus,
-  AuthOptions,
   createConnection,
   getListener,
   initialState,

--- a/src/hooks/useAuth.utils.ts
+++ b/src/hooks/useAuth.utils.ts
@@ -61,11 +61,7 @@ export const initialState: AuthState = Object.freeze({
 })
 
 export type AuthOptions = {
-  // The url used to initialize the SSO iframe.
-  // Defaults to https://id.decentraland.org
   ssoUrl?: string
-  // Determines if the SSO iframe should be initialized.
-  // Defaults to true
   ssoEnabled?: boolean
 }
 

--- a/src/hooks/useAuth.utils.ts
+++ b/src/hooks/useAuth.utils.ts
@@ -1,10 +1,10 @@
 import { ChainId, getChainName } from '@dcl/schemas/dist/dapps/chain-id'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
+import * as SSO from '@dcl/single-sign-on-client'
 import { connection } from 'decentraland-connect/dist/ConnectionManager'
 import { Provider } from 'decentraland-connect/dist/types'
 import { getChainConfiguration } from 'decentraland-dapps/dist/lib/chainConfiguration'
 import { AddEthereumChainParameters } from 'decentraland-dapps/dist/modules/wallet/types'
-import * as SSO from '@dcl/single-sign-on-client'
 
 import { Identity, identify } from '../utils/auth'
 import { ownerAddress } from '../utils/auth/identify'

--- a/src/hooks/useAuth.utils.ts
+++ b/src/hooks/useAuth.utils.ts
@@ -59,11 +59,6 @@ export const initialState: AuthState = Object.freeze({
   status: AuthStatus.Restoring,
 })
 
-export type AuthOptions = {
-  ssoUrl?: string
-  ssoEnabled?: boolean
-}
-
 let WINDOW_LISTENER: SingletonListener<Window> | null = null
 export function getListener(): SingletonListener<Window> {
   if (!WINDOW_LISTENER) {

--- a/src/utils/auth/storage.ts
+++ b/src/utils/auth/storage.ts
@@ -4,8 +4,8 @@ import * as SSO from '@dcl/single-sign-on-client'
 import Time from '../date/Time'
 import SingletonListener from '../dom/SingletonListener'
 import { PersistedKeys } from '../loader/types'
-import { Identity } from './types'
 import { ownerAddress } from './identify'
+import { Identity } from './types'
 
 const STORE_LEGACY_KEY = 'auth'
 let CURRENT_IDENTITY: Identity | null = null

--- a/src/utils/auth/storage.ts
+++ b/src/utils/auth/storage.ts
@@ -2,7 +2,6 @@ import { AuthLinkType } from '@dcl/crypto/dist/types'
 import * as SSO from '@dcl/single-sign-on-client'
 
 import Time from '../date/Time'
-import SingletonListener from '../dom/SingletonListener'
 import { PersistedKeys } from '../loader/types'
 import { ownerAddress } from './identify'
 import { Identity } from './types'
@@ -10,26 +9,6 @@ import { Identity } from './types'
 const STORE_LEGACY_KEY = 'auth'
 let CURRENT_IDENTITY: Identity | null = null
 let CURRENT_IDENTITY_RAW: string | null = null
-let STORAGE_LISTENER: SingletonListener<Window> | null = null
-
-function getStorageListener() {
-  if (STORAGE_LISTENER === null) {
-    STORAGE_LISTENER = SingletonListener.from(window)
-    // TODO: fix inter operativity with formatic
-    // STORAGE_LISTENER.addEventListener('storage', (event) => {
-    //   if (event.key !== PersistedKeys.Identity) {
-    //     return
-    //   }
-    //   CURRENT_IDENTITY = restoreIdentity()
-    //   // domain propagation
-    //   Promise.resolve().then(() => {
-    //     getStorateListener().dispatch(PersistedKeys.Identity as any, CURRENT_IDENTITY)
-    //   })
-    // })
-  }
-
-  return STORAGE_LISTENER!
-}
 
 export function isExpired(identity?: Identity) {
   if (!identity) {
@@ -70,7 +49,6 @@ export async function setCurrentIdentity(identity: Identity | null) {
 }
 
 export function getCurrentIdentity() {
-  getStorageListener()
   return CURRENT_IDENTITY
 }
 
@@ -95,10 +73,5 @@ async function storeIdentity(identity: Identity | null) {
 
       CURRENT_IDENTITY_RAW = null
     }
-
-    // local propagation
-    Promise.resolve().then(() => {
-      getStorageListener().dispatch(PersistedKeys.Identity as any, identity)
-    })
   }
 }


### PR DESCRIPTION
# Integrates Single Sign On:
AuthProvider components now receives both `ssoEnabled` and `ssoUrl` props.
With `ssoEnabled`, SSO will be initialized and an iframe used to store and retrieve the user identity will be used.
Prop `ssoUrl` determines the src provided to the iframe, uses "https://id.decentraland.org" as default.

Providing `ssoEnabled` as `false` or `undefined` will keep the previous behavior in case a dapp doesn't want to implement this.
The behavior is the same meaning that the identity is still stored in the application's localhost but stored using the logic found on `@dcl/single-sign-on-client` https://github.com/decentraland/single-sign-on-client/tree/main/packages/lib

Example:
```
<AuthProvider ssoEnabled ssoUrl="https://id.decentraland.zone">
...
</AuthProvider>
```

Tested locally on events and places!