### PR TITLE
fix: Only clear identity when actively signing out

### DIFF
--- a/src/components/User/UserMenu.tsx
+++ b/src/components/User/UserMenu.tsx
@@ -14,6 +14,7 @@ import { useFeatureFlagContext } from '../../context/FeatureFlag'
 import { DappsFeatureFlags } from '../../context/FeatureFlag/types'
 import useAsyncState from '../../hooks/useAsyncState'
 import useChainId from '../../hooks/useChainId'
+import { clearIdentity } from '../../utils/auth'
 import { fetchManaBalance } from '../../utils/loader/manaBalance'
 import Avatar from './Avatar'
 
@@ -118,7 +119,12 @@ export default function UserMenu(props: UserMenuProps) {
         manaBalances={manaBalances || {}}
         avatar={(profile || undefined) as any}
         newMenu={ff.enabled(DappsFeatureFlags.ProfileSite)}
-        onSignOut={() => userState.disconnect()}
+        onSignOut={async () => {
+          // Removes the identity from the SSO storage.
+          // This is the correct place to do it given that the user is actively signing out from the application.
+          await clearIdentity()
+          userState.disconnect()
+        }}
       />
     </div>
   )

--- a/src/utils/auth/storage.ts
+++ b/src/utils/auth/storage.ts
@@ -64,14 +64,16 @@ async function storeIdentity(identity: Identity | null) {
       await SSO.storeIdentity(account, identity)
       CURRENT_IDENTITY_RAW = JSON.stringify(identity)
     } else {
-      // If no identity is provided, clear the previous one if any.
-      if (CURRENT_IDENTITY_RAW) {
-        const prevIdentity = JSON.parse(CURRENT_IDENTITY_RAW)
-        const account = await ownerAddress(prevIdentity.authChain)
-        await SSO.clearIdentity(account)
-      }
-
       CURRENT_IDENTITY_RAW = null
     }
+  }
+}
+
+// Clears the identity from SSO.
+export async function clearIdentity() {
+  if (CURRENT_IDENTITY_RAW) {
+    const prevIdentity = JSON.parse(CURRENT_IDENTITY_RAW)
+    const account = await ownerAddress(prevIdentity.authChain)
+    await SSO.clearIdentity(account)
   }
 }


### PR DESCRIPTION
This prevents the identity from being deleted every time the user changes account of chain.