### PR TITLE
feat: Automatically prefix local links

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,4 @@
+import React from "react"
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 import type { StorybookConfig } from '@storybook/react-webpack5'
@@ -9,6 +10,13 @@ const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx|js|jsx|mdx)'],
   staticDirs: ['../static'],
   webpackFinal: async (config) => {
+    if (parseInt(React.version) <= 18) {
+      config.externals = ["react-dom/client"];
+    }
+    // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
+    if (config?.module?.rules?.[2]) {
+      (config.module.rules[2] as any).exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/]
+    }
     config.target = 'web'
     return config
   },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import React from "react"
+import React from 'react'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
 import type { StorybookConfig } from '@storybook/react-webpack5'
@@ -11,11 +11,13 @@ const config: StorybookConfig = {
   staticDirs: ['../static'],
   webpackFinal: async (config) => {
     if (parseInt(React.version) <= 18) {
-      config.externals = ["react-dom/client"];
+      config.externals = ['react-dom/client']
     }
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     if (config?.module?.rules?.[2]) {
-      (config.module.rules[2] as any).exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/]
+      ;(config.module.rules[2] as any).exclude = [
+        /node_modules\/(?!(gatsby|gatsby-script)\/)/,
+      ]
     }
     config.target = 'web'
     return config

--- a/src/components/Text/Link.tsx
+++ b/src/components/Text/Link.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react'
 
+import { withPrefix } from 'gatsby'
+
 import { isLocalLink } from '../../utils/dom/links'
 import TokenList from '../../utils/dom/TokenList'
 import { StyleNamespace } from '../../variables'
@@ -8,8 +10,13 @@ import './Link.css'
 
 export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
 
-export default React.memo(function Link({ target, rel, ...props }: LinkProps) {
-  const isLocal = useMemo(() => isLocalLink(props.href), [props.href])
+export default React.memo(function Link({
+  target,
+  rel,
+  href,
+  ...props
+}: LinkProps) {
+  const isLocal = useMemo(() => isLocalLink(href), [href])
   const linkTarget = useMemo(
     () => (!target && !isLocal ? '_blank' : target || undefined),
     [isLocal, target]
@@ -23,10 +30,11 @@ export default React.memo(function Link({ target, rel, ...props }: LinkProps) {
   return (
     <a
       {...props}
+      href={isLocal && href ? withPrefix(href) : href}
       className={TokenList.join([
         StyleNamespace,
         'Link',
-        (props.onClick || props.href) && 'Link--pointer',
+        (props.onClick || href) && 'Link--pointer',
         props.className,
       ])}
       target={linkTarget}


### PR DESCRIPTION
This PR fixes the issue we had with links in the newly prefixed sites where the anchors didn't have the prefix on their paths.
Anchors MUST be prefixed if they're local, as clicking them should consider the prefix. 