### PR TITLE
fix: Path variables

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,5 +3,5 @@ require('balloon-css/balloon.min.css')
 require('decentraland-ui/src/themes/base-theme.css')
 require('decentraland-ui/src/themes/alternative/light-theme.css')
 require('../src/variables.css')
-global.__BASE_PATH__ = '';
-global.__PATH_PREFIX__ = '';
+global.__BASE_PATH__ = ''
+global.__PATH_PREFIX__ = ''

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,3 +3,5 @@ require('balloon-css/balloon.min.css')
 require('decentraland-ui/src/themes/base-theme.css')
 require('decentraland-ui/src/themes/alternative/light-theme.css')
 require('../src/variables.css')
+global.__BASE_PATH__ = '';
+global.__PATH_PREFIX__ = '';


### PR DESCRIPTION
This PR adds the `__BASE_PATH__` and `__PATH_PREFIX__` globals to the storybook site which are needed for the links that use `withPrefix`.