### PR TITLE
fix: Allow switching networks for Magic or Wallet Connect

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -150,6 +150,7 @@ export default function Layout({
       <ShareModal data={shareState.data} onClose={shareState.close} />
       <WrongNetworkModal
         currentNetwork={state.chainId}
+        isSwitching={state.loading}
         expectedNetwork={getSupportedChainIds()}
         onSwitchNetwork={handleSwitchNetwork}
         providerType={state.providerType}

--- a/src/components/Modal/WrongNetworkModal.tsx
+++ b/src/components/Modal/WrongNetworkModal.tsx
@@ -87,7 +87,10 @@ export default React.memo(function WrongNetworkModal({
   )
 
   const allowNetworkSwitch = useMemo(
-    () => providerType === ProviderType.INJECTED,
+    () =>
+      providerType === ProviderType.INJECTED ||
+      providerType === ProviderType.MAGIC ||
+      providerType === ProviderType.WALLET_CONNECT_V2,
     [providerType]
   )
 

--- a/src/components/Modal/WrongNetworkModal.tsx
+++ b/src/components/Modal/WrongNetworkModal.tsx
@@ -12,6 +12,7 @@ export type WrongNetworkModalProps = ModalProps & {
   currentNetwork?: ChainId | null
   expectedNetwork?: ChainId | ChainId[]
   providerType?: ProviderType | null
+  isSwitching?: boolean
   onSwitchNetwork?: (chainId: ChainId) => void
 }
 
@@ -29,6 +30,7 @@ const anyNetwork = [
 export default React.memo(function WrongNetworkModal({
   open,
   currentNetwork,
+  isSwitching,
   expectedNetwork,
   onSwitchNetwork,
   providerType,
@@ -90,7 +92,8 @@ export default React.memo(function WrongNetworkModal({
     () =>
       providerType === ProviderType.INJECTED ||
       providerType === ProviderType.MAGIC ||
-      providerType === ProviderType.WALLET_CONNECT_V2,
+      providerType === ProviderType.WALLET_CONNECT_V2 ||
+      providerType === ProviderType.WALLET_CONNECT,
     [providerType]
   )
 
@@ -114,6 +117,8 @@ export default React.memo(function WrongNetworkModal({
             return (
               <Button
                 fluid
+                loading={isSwitching}
+                disabled={isSwitching}
                 key={chainId}
                 basic={index !== 0}
                 primary={index === 0}


### PR DESCRIPTION
This PR makes it possible to switch between networks if the user is using either Magic or Wallet Connect.
It also adds a loader to the modal's button to provide feedback to the user.