### PR TITLE
fix: Timeout release starting late

### DIFF
--- a/src/entities/Task/TaskManager.ts
+++ b/src/entities/Task/TaskManager.ts
@@ -108,11 +108,9 @@ export default class TaskManager {
       }, random(0, this._intervalTime))
 
       // run task timeout
-      setTimeout(async () => {
-        this._nextTimeoutRelease = setInterval(async () => {
-          await this.runTaskTimeout()
-        }, Time.Minute * 10)
-      }, random(Time.Minute, Time.Minute * 1000))
+      this._nextTimeoutRelease = setInterval(async () => {
+        await this.runTaskTimeout()
+      }, Time.Minute * 10)
     }
   }
 


### PR DESCRIPTION
The timeout release process was started a long time from starting the server due to being executed from a set timeout that was randomly chosen to be between a minute and 1000 minutes