### PR TITLE
fix: remove the bun job from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,6 @@ on:
       - master
 
 jobs:
-
-  bun:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v1
-
-      - name: Installing
-        run: bun install
-        continue-on-error: true
-
-      - name: Testing
-        run: bun test
-        continue-on-error: true
-
   node:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## what

remove the standalone `bun` job from `.github/workflows/release.yml`.

## why

the Release workflow ran a `bun` job (`oven-sh/setup-bun` → `bun install` → `bun test`) with `continue-on-error: true`. it gated nothing — the `node` job that runs the real lint/test/build/`semantic-release` pipeline doesn't depend on it — so it only added CI noise and minutes (and would silently "pass" even when bun failed).

## changes

- deleted the `bun` job; the `node` release job is unchanged.

## verification

- `release.yml` still parses as valid YAML with `jobs: [node]`.