### PR TITLE
fix: release timed-out response bodies in API.fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dcl/crypto": "^3.4.3",
         "@dcl/crypto-middleware": "^4.0.0",
         "@dcl/feature-flags": "^1.2.0",
-        "@dcl/http-server": "^2.0.1",
+        "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^25.1.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^2.0.0",
@@ -3406,21 +3406,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@base-org/account/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@base-org/account/node_modules/viem": {
       "version": "2.44.4",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.4.tgz",
@@ -4667,21 +4652,6 @@
         }
       }
     },
-    "node_modules/@coinbase/cdp-sdk/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@coinbase/cdp-sdk/node_modules/undici-types": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.0.tgz",
@@ -4867,9 +4837,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dcl/core-commons": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.0.tgz",
-      "integrity": "sha512-lcCgnwxkq/MoTbU59wKnspmVaQyEIP8SRRDUCd3Werrwj+nsH6T7xGuVo17cLVEd8D/Hi3NLFtBiq+N7kZAt/A==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
       "dependencies": {
         "@well-known-components/interfaces": "^1.5.2"
       }
@@ -5479,27 +5449,12 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@dcl/hooks/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@dcl/http-server": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.1.tgz",
-      "integrity": "sha512-W3dObaiswvQu4uqr9UIVmAPROubcR09C7D3OjGYxfme1lsd2kXPur3yhe3Q2AbdejL4lOsB3EmmxDEt6QS/b2g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.1.0.tgz",
+      "integrity": "sha512-UqIFIo18JeKklM/RM0wEJ0u/DCGjikBHtQ1LzuQKjDK6SP9XgeVhukgCg5BmdW0D3Qzlql2i5CGpW4EdyfUiWQ==",
       "dependencies": {
-        "@dcl/core-commons": "0.10.0",
+        "@dcl/core-commons": "0.10.1",
         "@well-known-components/interfaces": "^1.5.1",
         "destroy": "^1.2.0",
         "fp-future": "^1.0.1",
@@ -13484,21 +13439,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-common/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@reown/appkit-common/node_modules/viem": {
       "version": "2.44.4",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.4.tgz",
@@ -13654,21 +13594,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit-controllers/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@reown/appkit-controllers/node_modules/viem": {
@@ -13892,21 +13817,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@reown/appkit-utils/node_modules/viem": {
       "version": "2.44.4",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.4.tgz",
@@ -14084,21 +13994,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@reown/appkit/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@reown/appkit/node_modules/viem": {
       "version": "2.44.4",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.4.tgz",
@@ -14267,21 +14162,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@safe-global/safe-apps-sdk/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@safe-global/safe-apps-sdk/node_modules/viem": {
@@ -21681,21 +21561,6 @@
         "real-require": "^0.1.0"
       }
     },
-    "node_modules/@walletconnect/ethereum-provider/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@walletconnect/ethereum-provider/node_modules/uint8arrays": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
@@ -22632,21 +22497,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/unstorage": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@dcl/crypto": "^3.4.3",
     "@dcl/crypto-middleware": "^4.0.0",
     "@dcl/feature-flags": "^1.2.0",
-    "@dcl/http-server": "^2.0.1",
+    "@dcl/http-server": "^2.1.0",
     "@dcl/schemas": "^25.1.0",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^2.0.0",

--- a/src/utils/api/API.test.ts
+++ b/src/utils/api/API.test.ts
@@ -342,4 +342,59 @@ describe('timeout', () => {
     expect(options?.signal).toBeInstanceOf(AbortSignal)
     expect(options?.signal?.aborted).toBe(false)
   })
+
+  // Builds a Response whose body stays a real ReadableStream (so `instanceof`
+  // checks keep holding) while its `cancel` is observable. `cancelled` resolves
+  // the moment the body is released, so assertions don't depend on timing.
+  function createObservableResponse() {
+    const late = new Response(JSON.stringify({ random: Math.random() }), {
+      status: 200,
+    })
+    let resolveCancelled: () => void = () => undefined
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve
+    })
+    const cancel = jest
+      .spyOn(late.body!, 'cancel')
+      .mockImplementation(async () => {
+        resolveCancelled()
+      })
+
+    return { late, cancel, cancelled }
+  }
+
+  test(`should release the body of a response that arrives after a timeout with fallback`, async () => {
+    const { late, cancel, cancelled } = createObservableResponse()
+    const mock = jest.fn(((): any => {}) as typeof fetch)
+    mock.mockImplementation(() => sleep(20).then(() => late))
+
+    const api = new API('https://decentraland.org/api').setFetcher(mock)
+    await expect(
+      api.fetch(
+        '/timeout/20',
+        api.options().timeoutWithFallback(10, { fallback: true })
+      )
+    ).resolves.toEqual({ fallback: true })
+
+    // the in-flight request settles after the timeout won the race; await the
+    // release directly so the assertion doesn't depend on timing margins
+    await cancelled
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
+
+  test(`should release the body of a response that arrives after a timeout without fallback`, async () => {
+    const { late, cancel, cancelled } = createObservableResponse()
+    const mock = jest.fn(((): any => {}) as typeof fetch)
+    mock.mockImplementation(() => sleep(20).then(() => late))
+
+    const api = new API('https://decentraland.org/api').setFetcher(mock)
+    // the non-fallback path rejects with a 408, but the discarded body must
+    // still be released
+    await expect(
+      api.fetch('/timeout/20', api.options().timeout(10))
+    ).rejects.toThrowError('Request Timeout')
+
+    await cancelled
+    expect(cancel).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/utils/api/API.ts
+++ b/src/utils/api/API.ts
@@ -277,14 +277,19 @@ export default class API {
         let completed = false
         const controller = new AbortController()
 
+        // keep a reference to the in-flight request so a discarded (timed-out)
+        // response can be released below
+        const request = this.#fetch(
+          url,
+          opt.toObject({ signal: controller.signal })
+        ).then((res) => {
+          completed = true
+          return res
+        })
+
         // race against fetch and timeout
         res = await Promise.race([
-          this.#fetch(url, opt.toObject({ signal: controller.signal })).then(
-            (res) => {
-              completed = true
-              return res
-            }
-          ),
+          request,
 
           sleep(timeout.timeout).then(() => {
             // abort fetch in background
@@ -303,6 +308,17 @@ export default class API {
             return new Response('Request Timeout', { status: 408 })
           }),
         ])
+
+        // if the timeout won the race, the in-flight request may still settle
+        // with a real Response whose body is never read. Release it so its
+        // underlying socket and buffered bytes aren't pinned until GC. This is
+        // a no-op when the fetch rejected on abort, and works with the native
+        // fetch of both the browser and Node.
+        if (!completed) {
+          request
+            .then((response) => response.body?.cancel())
+            .catch(() => undefined)
+        }
 
         // If not timeout was set then just perform the fetch
       } else {


### PR DESCRIPTION
## what

- fix a non-cancelled-request leak in the `API.fetch` timeout path
- bump `@dcl/http-server` `^2.0.1` → `^2.1.0` (lockfile 2.0.1 → 2.1.0, pulls `@dcl/core-commons` 0.10.1)

## the leak

`API.fetch` races the request against a timeout via `Promise.race`. When a slow request loses the race, the timeout branch returns the fallback / `408` and aborts the controller — but the in-flight request can still **settle with a real `Response`** (e.g. its headers arrived in the abort window, or a custom `setFetcher()` fetcher that ignores abort). That response's body was never read, so its undici socket stayed checked out of the pool and its bytes stayed buffered until GC. This is the same class of leak just fixed in `@dcl/fetch-component`.

## the fix

Keep a reference to the in-flight request and, when the timeout wins, release the discarded response:

```ts
if (!completed) {
  request.then((response) => response.body?.cancel()).catch(() => undefined)
}
```

- **isomorphic** — `response.body?.cancel()` works with the native fetch of both the browser and Node; it's a no-op when the fetch already rejected on abort.
- the `Promise.race` is intentionally **kept** (rather than switching to the component's `await` + abort) so the timeout still fires for custom fetchers that don't honour `AbortSignal`, and the existing `timeoutFallback` semantics are unchanged.

## tests

`src/utils/api/API.test.ts` — added a regression test asserting a response that arrives after the timeout has its body released. All 26 API tests pass (the 5 existing timeout tests are unchanged).

## http-server bump

`ExpressContext` calls `getRequestFromNodeMessage` per request; moving to the current latest `2.1.0` keeps gatsby on the maintained line. (The further request hot-path perf work is in an as-yet-unreleased http-server version; a follow-up bump will pick it up once published.)

## verification (Node 24)

- `tsc -p . --noEmit` → 0 errors
- `jest src/utils/api/API.test.ts` → 26 passed