### PR TITLE
fix: escape image and url metadata values in replaceHelmetMetadata

### DIFF
--- a/src/entities/Gatsby/utils.test.ts
+++ b/src/entities/Gatsby/utils.test.ts
@@ -33,5 +33,26 @@ describe(`src/entities/Gatsby/utils`, () => {
 
       expect(min(replaceHelmetMetadata(initial, meta))).toBe(min(injected))
     })
+
+    describe(`when the image and url values contain HTML-breakout characters`, () => {
+      let output: string
+      let breakout: string
+
+      beforeEach(() => {
+        breakout = `https://a"><script>alert(1)</script><meta name="x`
+        output = replaceHelmetMetadata(initial, {
+          image: breakout,
+          url: breakout,
+        })
+      })
+
+      it(`should render the injected script as escaped text instead of a live element`, () => {
+        expect(output).toContain(`&lt;script&gt;alert(1)&lt;/script&gt;`)
+      })
+
+      it(`should not break out of the content attribute with a raw double quote`, () => {
+        expect(output).not.toContain(`content="https://a">`)
+      })
+    })
   })
 })

--- a/src/entities/Gatsby/utils.test.ts
+++ b/src/entities/Gatsby/utils.test.ts
@@ -54,5 +54,45 @@ describe(`src/entities/Gatsby/utils`, () => {
         expect(output).not.toContain(`content="https://a">`)
       })
     })
+
+    describe(`when a metadata key contains HTML-breakout characters`, () => {
+      let output: string
+      let breakoutKey: string
+
+      beforeEach(() => {
+        breakoutKey = `x"><script>alert(1)</script><meta name="y`
+        output = replaceHelmetMetadata(initial, {
+          [breakoutKey]: 'value',
+        } as Partial<MetadataOptions>)
+      })
+
+      it(`should render the injected script as escaped text instead of a live element`, () => {
+        expect(output).toContain(`&lt;script&gt;alert(1)&lt;/script&gt;`)
+      })
+
+      it(`should not break out of the name attribute with a raw double quote`, () => {
+        expect(output).not.toContain(`name="x">`)
+      })
+    })
+
+    describe(`when an og: metadata key contains HTML-breakout characters`, () => {
+      let output: string
+      let breakoutKey: string
+
+      beforeEach(() => {
+        breakoutKey = `og:x"><script>alert(1)</script><meta property="y`
+        output = replaceHelmetMetadata(initial, {
+          [breakoutKey]: 'value',
+        } as Partial<MetadataOptions>)
+      })
+
+      it(`should render the injected script as escaped text instead of a live element`, () => {
+        expect(output).toContain(`&lt;script&gt;alert(1)&lt;/script&gt;`)
+      })
+
+      it(`should not break out of the property attribute with a raw double quote`, () => {
+        expect(output).not.toContain(`property="og:x">`)
+      })
+    })
   })
 })

--- a/src/entities/Gatsby/utils.ts
+++ b/src/entities/Gatsby/utils.ts
@@ -72,20 +72,18 @@ export function createHelmetMetadataReplacer(page: string) {
           break
         }
 
-        default:
+        default: {
+          // The metadata key is interpolated into an attribute too, so it must be
+          // escaped as well — an unescaped key could otherwise break out of the
+          // `name`/`property` attribute even when the value is safe.
+          const key = escape(name)
+          const value = escape(String(metadata[name] ?? ''))
           if (name.startsWith('og:')) {
-            injected.push(
-              `<meta property="${name}" content="${escape(
-                String(metadata[name] ?? '')
-              )}" />`
-            )
+            injected.push(`<meta property="${key}" content="${value}" />`)
           } else {
-            injected.push(
-              `<meta name="${name}" content="${escape(
-                String(metadata[name] ?? '')
-              )}" />`
-            )
+            injected.push(`<meta name="${key}" content="${value}" />`)
           }
+        }
       }
     }
 

--- a/src/entities/Gatsby/utils.ts
+++ b/src/entities/Gatsby/utils.ts
@@ -58,23 +58,19 @@ export function createHelmetMetadataReplacer(page: string) {
           )
           break
         }
-        case `image`:
-          injected.push(
-            `<meta name="twitter:image" content="${metadata[name]}" />`
-          )
-          injected.push(
-            `<meta property="og:image" content="${metadata[name]}" />`
-          )
+        case `image`: {
+          const image = escape(String(metadata[name] ?? ''))
+          injected.push(`<meta name="twitter:image" content="${image}" />`)
+          injected.push(`<meta property="og:image" content="${image}" />`)
           break
+        }
 
-        case `url`:
-          injected.push(
-            `<meta name="twitter:url" content="${metadata[name]}" />`
-          )
-          injected.push(
-            `<meta property="og:url" content="${metadata[name]}" />`
-          )
+        case `url`: {
+          const url = escape(String(metadata[name] ?? ''))
+          injected.push(`<meta name="twitter:url" content="${url}" />`)
+          injected.push(`<meta property="og:url" content="${url}" />`)
           break
+        }
 
         default:
           if (name.startsWith('og:')) {


### PR DESCRIPTION
## what

`replaceHelmetMetadata` escaped `title` and `description` before interpolating them into `<meta content="...">` attributes, but injected the `image` and `url` values **raw**, then reparsed the resulting string as html. an attacker-controlled value like:

```
https://x"><script>alert(1)</script><meta name="y
```

breaks out of the `content="..."` attribute and becomes a live `<script>` element in `<head>`. any consumer that renders attacker-controlled image/url metadata is exposed — notably the places social/opengraph endpoint (`/places/place/`, `/places/world/`), which passes `Place.image` here after storing a scene's `navmapThumbnail`. the result is a stored xss / defacement served from the official places origin.

## change

escape `image` and `url` with the same `escape()` helper already used for `title`, `description`, and the default `og:`/`name` branches, so every metadata value is contextually encoded before html insertion.

## defense-in-depth context

this is the html-sink layer. the payload is also blocked upstream:
- deployment gate: [core-libs#55](https://github.com/decentraland/core-libs/pull/55) (catalyst scenes) and [worlds-content-server#514](https://github.com/decentraland/worlds-content-server/pull/514) (worlds) reject non-relative `navmapThumbnail` values.
- ingestion: places `sanitizeImageUrl` (separate places PR) rejects non-http(s) thumbnails before storing them.

the sink-level escape still matters because it protects already-deployed / grandfathered records and any other caller of `replaceHelmetMetadata`.

## release / rollout

this repo publishes via semantic-release, so the `fix:` commit will cut a patch release on merge. consumers (places) then need a dependency bump to pick it up. no manual `package.json` version change is included, per the semantic-release flow.

## tests

added coverage asserting a breakout value in `image` and `url` is rendered as escaped text (not a live `<script>`) and does not close the `content` attribute. suite green (`4/4`).