### PR TITLE
fix(deps): upgrade @dcl/crypto-middleware to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-ses": "^3.421.0",
         "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "^3.4.3",
-        "@dcl/crypto-middleware": "6.2.0",
+        "@dcl/crypto-middleware": "6.3.0",
         "@dcl/feature-flags": "^1.2.0",
         "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^25.1.0",
@@ -4861,9 +4861,9 @@
       }
     },
     "node_modules/@dcl/crypto-middleware": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-6.2.0.tgz",
-      "integrity": "sha512-wffOAA7AqzXkfQ7OxbRbUTSk1p478SXLibwFcAoSUiW2Z1+QOdTQI+w54rNt1JUuZX/V7QVuhYw1qxUEBquTkw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-6.3.0.tgz",
+      "integrity": "sha512-HUwaPBuXjf3xSGIcnwm52NIZchaPg0rDe/bsjlYdo4ZpjuTlTeQ8m7fjTT3V14/pRTa55T404eHGZURU5jJDog==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/core-commons": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@aws-sdk/client-ses": "^3.421.0",
     "@dcl/core-commons": "^0.10.0",
     "@dcl/crypto": "^3.4.3",
-    "@dcl/crypto-middleware": "6.2.0",
+    "@dcl/crypto-middleware": "6.3.0",
     "@dcl/feature-flags": "^1.2.0",
     "@dcl/http-server": "^2.1.0",
     "@dcl/schemas": "^25.1.0",

--- a/src/entities/Auth/routes/withDecentralandAuth.test.ts
+++ b/src/entities/Auth/routes/withDecentralandAuth.test.ts
@@ -50,6 +50,24 @@ function signSceneRequestWithPaddedSigner(signer: string) {
   })
 }
 
+/**
+ * Signs and delivers the scene signer under a re-spelled key — `Signer`, not `signer`.
+ *
+ * Signed as delivered, so the signature is genuinely valid: re-spelling the key changes the signed
+ * bytes, and a scene-driven client can simply sign them that way. Up to @dcl/crypto-middleware 6.2.0
+ * the predicates read the exact key, so `Signer` presented no `signer` at all, every predicate read
+ * the field as absent, and `rejectIfSigner` answered "allowed" for metadata that visibly names the
+ * signer it exists to refuse. 6.3.0 treats a key that case-folds to the declared field without being
+ * spelled exactly that as a rejection rather than an absence. Nothing is folded — the value is
+ * refused, never rewritten.
+ */
+function signSceneRequestWithRecasedSignerKey() {
+  return signRequest(new Request('http://0.0.0.0/'), {
+    identity,
+    metadata: { Signer: 'decentraland-kernel-scene' },
+  })
+}
+
 const PADDED_SCENE_SIGNERS: Array<[string, string]> = [
   ['a leading space', ' decentraland-kernel-scene'],
   ['a trailing space', 'decentraland-kernel-scene '],
@@ -250,6 +268,27 @@ describe(`withAuth`, () => {
     }
   )
 
+  describe('when the scene signer is delivered under a re-spelled key', () => {
+    let logger: Logger
+    let request: Request
+
+    beforeEach(() => {
+      logger = new Logger({}, { disabled: true })
+      jest.spyOn(logger, 'error').mockImplementation(() => null)
+      request = signSceneRequestWithRecasedSignerKey()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should fail instead of reading the signer as absent', async () => {
+      await expect(() => withAuth({ request, logger })).rejects.toThrow(
+        'Invalid signer'
+      )
+    })
+  })
+
   test(`should return auth data for signed request`, async () => {
     const request = signRequest(new Request('http://0.0.0.0/'), {
       identity,
@@ -316,6 +355,25 @@ describe(`withAuthOptional`, () => {
       expect(await withAuthOptional({ request, logger })).toBe(null)
     }
   )
+
+  describe('when the scene signer is delivered under a re-spelled key', () => {
+    let logger: Logger
+    let request: Request
+
+    beforeEach(() => {
+      logger = new Logger({}, { disabled: true })
+      jest.spyOn(logger, 'error').mockImplementation(() => null)
+      request = signSceneRequestWithRecasedSignerKey()
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should return null instead of reading the signer as absent', async () => {
+      expect(await withAuthOptional({ request, logger })).toBe(null)
+    })
+  })
 
   test(`should return auth data for signed request`, async () => {
     const request = signRequest(new Request('http://0.0.0.0/'), {


### PR DESCRIPTION
## Why this needs a gatsby release

`@dcl/crypto-middleware` is pinned **exactly** here — `"@dcl/crypto-middleware": "6.2.0"`, not a caret range. Every app that gets the middleware transitively through gatsby therefore resolves 6.2.0 no matter what they do on their side: they cannot pick up 6.3.0 at all until this merges and gatsby publishes. That is the point of this PR — the fix is already on npm, and gatsby is the thing standing between it and its consumers.

## The hole 6.3.0 closes

6.3.0 adds a `hasFoldedVariant` guard to `canonicalField` and `requireCanonicalField`, which `rejectIfSigner` and `requireSigner` are built on.

Until now those predicates read the **exact** key. So metadata delivering `{"Signer":"decentraland-kernel-scene"}` presented no `signer` field at all, and every predicate treated it as *absent*.

`verifySigner` in `src/entities/Auth/utils.ts` — the default `metadataValidator` behind `withAuth` and `withAuthOptional` — is built on `rejectIfSigner('decentraland-kernel-scene')`. It therefore answered "allowed" for metadata that visibly names the signer it exists to refuse.

This is **not** only the lenient/legacy path. It is reachable on the strict current-format path: re-spelling the key changes the signed bytes, so the request has to be signed that way — which a malicious scene-driven client can simply do. The signature is then genuinely valid, byte binding has nothing to object to, and only the gate could refuse it. It could not. That is a real bypass of the scene gate.

Under 6.3.0, a key that case-folds to the declared field without being spelled exactly that is a **rejection** rather than an absence. Nothing is folded — the value is refused, never rewritten.

## What is in here

- `package.json`: `6.2.0` → `6.3.0`, exact pin preserved.
- `package-lock.json`: **4 lines**. 6.3.0 carries the same dependencies as 6.2.0 (`@dcl/core-commons@^0.10.0`, `@dcl/crypto@3.7.0`), so only the version, the resolved URL and the integrity change, plus the root reference. `npm install` wanted to rewrite ~700 unrelated lines — re-normalising `peer`/`license` metadata and **pruning 20 optional platform packages** (`os`/`cpu` entries), which would have broken installs on other architectures. That churn was reverted and the entry updated surgically; `npm ci` then passes against the result and reinstalls 6.3.0 cleanly.
- A regression test through gatsby's own auth surface, in both the required and the optional route helper.

The pin stays exact because `src/utils/auth/payload.ts` still deep-imports `@dcl/crypto-middleware/dist/verify` for `createPayload`. That path is confirmed present in 6.3.0.

## Counterfactual

The new tests are worthless if they pass either way, so both were run against 6.2.0.

**Against 6.2.0 they fail — and they fail by succeeding.** `withAuth` did not throw; it *resolved*:

```
Received promise resolved instead of rejected
Resolved to value: {"address": "0xb92702b3eefb3c2049aeb845b0335b283e11e9c6",
                    "metadata": {"Signer": "decentraland-kernel-scene"}}
```

A scene-signed request served as a directly user-signed one, with the scene signer sitting in plain sight in the metadata. `withAuthOptional` likewise returned the auth data instead of `null`.

**Against 6.3.0 both pass.** All 23 pre-existing tests in the file pass under both versions, so the new tests are specific to this guard and nothing else regressed.

## Tests run

- `src/entities/Auth/routes/withDecentralandAuth.test.ts` — 25 passed (23 pre-existing + 2 new)
- `src/utils/api/API.test.ts` — 30 passed (signing side, deep-imports the middleware)
- `tsc --noEmit` — 0 errors project-wide
- `eslint` and `prettier --check` on the touched files — clean

The full suite was deliberately not run.

## Downstream

`referral`, `places` and `events` consume gatsby's auth. They are being assessed separately and are **not** touched here. None of them can pick up 6.3.0 before this ships.
